### PR TITLE
idKey + getId => id

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -57,7 +57,7 @@ h)
 </Masonry>
 ```
 
-**Note**: On non-primitive items, i.e. if `items` is an array of objects, this component by default tries to access a key named `'id'` on each item. This value is used to tell items apart in the keyed `{#each}` block that renders the masonry layout. Without it, Svelte could not avoid duplicates when new items are added or existing ones rearranged. Read the [Svelte docs](https://svelte.dev/tutorial/keyed-each-blocks) for details. To change the name of the identifier key, use the `idKey` prop. You can also pass in a custom function as `getId` that should map items to unique IDs.
+**Note**: On non-primitive items, i.e. if `items` is an array of objects, this component by default tries to access a key named `'id'` on each item. This value is used to tell items apart in the keyed `{#each}` block that renders the masonry layout. Without it, Svelte could not avoid duplicates when new items are added or existing ones rearranged. Read the [Svelte docs](https://svelte.dev/tutorial/keyed-each-blocks) for details. Pass in a custom function or string as `id` that should map items to unique IDs.
 
 **Hint**: Balanced columns can be achieved even with this simple implementation if masonry items are allowed to stretch to the column height.
 
@@ -73,8 +73,7 @@ Additional optional props are:
 - `gap: number = 20` (in `px`)
 - `masonryWidth: number = 0`: Bound to the masonry `div`s width (in `px`).
 - `masonryHeight: number = 0`: Bound to the masonry `div`s height (in `px`).
-- `idKey: string = 'id'`: Name of the attribute to use as identifier if items are objects.
-- `getId: (item) => string | number`: Custom function that maps masonry items to unique IDs.
+- `id: (item) => string | Function`: Custom function that maps masonry items to unique IDs.
 - `animate: boolean = true`: Whether to [FLIP-animate](https://svelte.dev/tutorial/animate) masonry items when viewport resizing or other events cause `items` to rearrange.
 - `style: string = ''`: Inline styles that will be applied to the top-level `div.masonry`.
 - `duration: number = 200`: Transition duration in milli seconds when masonry items are rearranged or added/removed. Set to 0 to disable transitions.

--- a/src/lib/Masonry.svelte
+++ b/src/lib/Masonry.svelte
@@ -1,78 +1,150 @@
-<script lang="ts">
-  import { flip } from 'svelte/animate'
-  import { fade } from 'svelte/transition'
+<script>
+  import { gsap } from 'gsap'
+  import { data } from '$lib/data/home/06'
+  import { getContext } from 'svelte'
 
-  export let items: Item[]
-  export let minColWidth = 330
-  export let maxColWidth = 500
-  export let gap = 20
-  export let masonryWidth = 0
-  export let masonryHeight = 0
-  export let animate = true
-  export let style = ``
-  export let duration = 200
+  export let key
+  export let pct = 0
+  export let width = 0 // width of chart
 
-  export { className as class }
-  export let columnClass = ``
-  // On non-primitive types, we need a property to tell masonry items apart. This component
-  // hard-codes the name of this property to 'id'. See https://svelte.dev/tutorial/keyed-each-blocks.
-  export let idKey = `id`
-  export let getId = (item: Item) => {
-    if (typeof item === `string`) return item
-    if (typeof item === `number`) return item
-    return (item as Record<string, unknown>)[idKey]
+  const { explainer, legend } = getContext('copy')
+
+  const personAspectRatio = 43 / 50
+
+  // gsap
+  let tickerEl
+  let explainerHeight = 16
+
+  $: grid = { x: width < 640 ? 10 : 24, y: 5 }
+
+  $: margin = {
+    top: width > 640 ? explainerHeight : spaceHeight * 1.15,
+    right: 0,
+    bottom: 0,
+    left: 0,
   }
+  $: spaceWidth = width / grid.x // width of people
+  $: chartHeight = spaceWidth * (1 / personAspectRatio) * grid.y // height of people chart, which is dynamic based on the width of the people
+  $: containerHeight = chartHeight + margin.top // height of full container, which includes top margin
+  $: spaceHeight = chartHeight / grid.y // height of people
 
-  type Item = $$Generic
-  let className = ``
-
-  $: nCols = Math.min(items.length, Math.floor(masonryWidth / (minColWidth + gap)) || 1)
-  $: itemsToCols = items.reduce(
-    (cols: [Item, number][][], item, idx) => {
-      cols[idx % cols.length].push([item, idx])
-      return cols
-    },
-    Array(nCols).fill(null).map(() => []) // prettier-ignore
-  )
+  $: if (tickerEl && key)
+    gsap.timeline().counter(
+      tickerEl,
+      {
+        end: pct,
+        increment: 1,
+        duration: 1,
+      },
+      0
+    )
 </script>
 
-<div
-  class="masonry {className}"
-  bind:clientWidth={masonryWidth}
-  bind:clientHeight={masonryHeight}
-  style="gap: {gap}px; {style}"
->
-  {#each itemsToCols as col}
-    <div class="col {columnClass}" style="gap: {gap}px; max-width: {maxColWidth}px;">
-      {#if animate}
-        {#each col as [item, idx] (getId(item))}
-          <div
-            in:fade|local={{ delay: 100, duration }}
-            out:fade|local={{ delay: 0, duration }}
-            animate:flip={{ duration }}
-          >
-            <slot {idx} {item} />
-          </div>
-        {/each}
-      {:else}
-        {#each col as [item, idx] (getId(item))}
-          <slot {idx} {item} />
-        {/each}
-      {/if}
-    </div>
-  {/each}
-</div>
+<figure class="w-full" bind:clientWidth={width}>
+  <figcaption
+    class="axis my-4 mb-8 w-full bg-white bg-opacity-50 text-shadow md:my-0 md:absolute md:left-0 md:-top-4 md:max-w-[60%]"
+    bind:clientHeight={explainerHeight}
+  >
+    {@html explainer[key]}
+  </figcaption>
 
-<style>
-  :where(div.masonry) {
-    display: flex;
-    justify-content: center;
-    overflow-wrap: anywhere;
-    box-sizing: border-box;
+  <div class="relative my-4 md:my-12" style:height="{containerHeight}px">
+    <div class="absolute inset-0 h-full grid grid-cols-10 md:grid-cols-3">
+      {#each ['Denied', 'Approved'] as quadrant, i}
+        {@const isApproved = quadrant === 'Approved'}
+        {@const border = i === 0 ? '' : 'border-x-[1px]'}
+        <div
+          class="relative {border} border-secondary-lighter border-opacity-40 p-1 h-full"
+          class:approved-bg={isApproved}
+        >
+          {#if isApproved}
+            <p
+              class="absolute whitespace-nowrap left-1/2 -top-4 transform -translate-x-1/2 bg-primary-dark bg-opacity-80 text-base md:text-xl callout-sm text-white font-semibold rounded px-3 py-2"
+            >
+              <span bind:this={tickerEl}>0</span>
+              <small>%</small>
+              <span class="inline">&nbsp;Approved</span>
+            </p>
+          {/if}
+        </div>
+      {/each}
+    </div>
+
+    <div class="w-full h-full relative overflow-hidden">
+      {#each data[width < 640 ? 'mobile' : 'desktop'] as person (person.id)}
+        {@const src = `images/people/${person.color}/Person_${person.person}`}
+        {@const x = spaceWidth * (+person.steps[key].x - 1)}
+        {@const y = chartHeight - spaceHeight * +person.steps[key].y + margin.top}
+        <picture>
+          {#each ['avif', 'webp'] as format}
+            <source srcset="{src}.{format}" type="image/{format}" />
+          {/each}
+          <img
+            src="{src}.png"
+            alt="Silhouette of a person"
+            width="20.64"
+            height="24"
+            loading="lazy"
+            decoding="async"
+            draggable="false"
+            class="absolute person will-change-transform transition-all duration-1000"
+            class:opacity-10={person.steps[key].y > grid.y}
+            class:opacity-50={person.steps[key].y === grid.y}
+            class:opacity-75={person.steps[key].y === grid.y - 1}
+            style:width="{spaceWidth}px"
+            style:transform="translate({x}px, {y}px)"
+            style:transition-delay="{(person.id - 1) * 3}ms"
+            data-id={person.id}
+            data-x={person.steps[key].x}
+            data-y={person.steps[key].y}
+          />
+        </picture>
+      {/each}
+    </div>
+  </div>
+
+  <div
+    class="w-full flex flex-col justify-between items-start mt-4 gap-2 sm:flex-row sm:items-center "
+  >
+    <p class="axis leading-none text-primary-dark">
+      {@html legend.title}
+      <i class="fa-light fa-arrow-right ml-1 leading-none align-middle" />
+    </p>
+    <div class="flex items-center gap-x-6">
+      {#each legend.entries as { src, caption }}
+        <figure class="flex items-center">
+          <picture>
+            {#each ['avif', 'webp'] as format}
+              <source srcset="{src}.{format}" type="image/{format}" />
+            {/each}
+            <img
+              loading="lazy"
+              decoding="async"
+              draggable="false"
+              width="20.64"
+              height="24"
+              src="{src}.png"
+              alt="Silhouette of a person"
+            />
+          </picture>
+
+          <figcaption class="axis leading-none">{caption}</figcaption>
+        </figure>
+      {/each}
+    </div>
+  </div>
+</figure>
+
+<style lang="postcss">
+  .approved-bg {
+    background: linear-gradient(
+      180deg,
+      rgba(140, 207, 176, 0.25) 32.68%,
+      rgba(140, 207, 176, 0) 100%
+    );
+    @apply col-start-7 col-span-4 md:col-span-1 md:col-start-3;
   }
-  :where(div.masonry div.col) {
-    display: grid;
-    height: max-content;
-    width: 100%;
+  img {
+    transition-timing-function: cubic-bezier(0.33, 1, 0.68, 1);
   }
 </style>


### PR DESCRIPTION
This was something a bit more along the lines of what I was thinking of having one prop (`id`) that can be used as a string or function. I'm not used to Typescript so pardon any errors.

There's a typeof to check if it's an iterator. That value is then passed to the keyed each block's identifier. It reduces it to one and prevents the option of people passing both `keyId` and `getId`. Passing `getId` by default renders `keyId` useless