### PR TITLE
Consolidate key prop

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -73,7 +73,6 @@ Additional optional props are:
 - `gap: number = 20` (in `px`)
 - `masonryWidth: number = 0`: Bound to the masonry `div`s width (in `px`).
 - `masonryHeight: number = 0`: Bound to the masonry `div`s height (in `px`).
-- `idKey: string = 'id'`: Name of the attribute to use as identifier if items are objects.
 - `id: (item) => string | Function`: Custom function that maps masonry items to unique IDs.
 - `animate: boolean = true`: Whether to [FLIP-animate](https://svelte.dev/tutorial/animate) masonry items when viewport resizing or other events cause `items` to rearrange.
 - `style: string = ''`: Inline styles that will be applied to the top-level `div.masonry`.

--- a/readme.md
+++ b/readme.md
@@ -57,7 +57,7 @@ h)
 </Masonry>
 ```
 
-**Note**: On non-primitive items, i.e. if `items` is an array of objects, this component by default tries to access a key named `'id'` on each item. This value is used to tell items apart in the keyed `{#each}` block that renders the masonry layout. Without it, Svelte could not avoid duplicates when new items are added or existing ones rearranged. Read the [Svelte docs](https://svelte.dev/tutorial/keyed-each-blocks) for details. To change the name of the identifier key, use the `idKey` prop. You can also pass in a custom function as `getId` that should map items to unique IDs.
+**Note**: On non-primitive items, i.e. if `items` is an array of objects, this component by default tries to access a key named `'id'` on each item. This value is used to tell items apart in the keyed `{#each}` block that renders the masonry layout. Without it, Svelte could not avoid duplicates when new items are added or existing ones rearranged. Read the [Svelte docs](https://svelte.dev/tutorial/keyed-each-blocks) for details. To change the name of the identifier key, use the `idKey` prop. Pass in a function or string as `id` to locate unique identifiers.
 
 **Hint**: Balanced columns can be achieved even with this simple implementation if masonry items are allowed to stretch to the column height.
 
@@ -74,7 +74,7 @@ Additional optional props are:
 - `masonryWidth: number = 0`: Bound to the masonry `div`s width (in `px`).
 - `masonryHeight: number = 0`: Bound to the masonry `div`s height (in `px`).
 - `idKey: string = 'id'`: Name of the attribute to use as identifier if items are objects.
-- `getId: (item) => string | number`: Custom function that maps masonry items to unique IDs.
+- `id: (item) => string | Function`: Custom function that maps masonry items to unique IDs.
 - `animate: boolean = true`: Whether to [FLIP-animate](https://svelte.dev/tutorial/animate) masonry items when viewport resizing or other events cause `items` to rearrange.
 - `style: string = ''`: Inline styles that will be applied to the top-level `div.masonry`.
 - `duration: number = 200`: Transition duration in milli seconds when masonry items are rearranged or added/removed. Set to 0 to disable transitions.

--- a/src/lib/Masonry.svelte
+++ b/src/lib/Masonry.svelte
@@ -29,12 +29,13 @@
   const isIterator: boolean = typeof id === `function`
 
   $: nCols = Math.min(items.length, Math.floor(masonryWidth / (minColWidth + gap)) || 1)
+
   $: itemsToCols = items.reduce(
     (cols: [Item, number][][], item, idx) => {
       cols[idx % cols.length].push([item, idx])
       return cols
     },
-    Array(nCols).fill(null).map(() => []) // prettier-ignore
+    Array.from({ length: nCols }, () => [])
   )
 </script>
 

--- a/src/lib/Masonry.svelte
+++ b/src/lib/Masonry.svelte
@@ -3,28 +3,30 @@
   import { fade } from 'svelte/transition'
 
   export let items: Item[]
-  export let minColWidth = 330
-  export let maxColWidth = 500
-  export let gap = 20
-  export let masonryWidth = 0
-  export let masonryHeight = 0
-  export let animate = true
-  export let style = ``
-  export let duration = 200
+  export let minColWidth: number = 330
+  export let maxColWidth: number = 500
+  export let gap: number = 20
+  export let masonryWidth: number = 0
+  export let masonryHeight: number = 0
+  export let animate: boolean = true
+  export let style: string = ``
+  export let duration: number = 200
 
   export { className as class }
-  export let columnClass = ``
+  export let columnClass: string = ``
+
   // On non-primitive types, we need a property to tell masonry items apart. This component
   // hard-codes the name of this property to 'id'. See https://svelte.dev/tutorial/keyed-each-blocks.
-  export let idKey = `id`
-  export let getId = (item: Item) => {
+  export let id: string | Function = (item: Item) => {
     if (typeof item === `string`) return item
     if (typeof item === `number`) return item
-    return (item as Record<string, unknown>)[idKey]
+    return (item as Record<string, unknown>).id
   }
 
   type Item = $$Generic
-  let className = ``
+  let className: string = ``
+
+  const isIterator: boolean = typeof id === `function`
 
   $: nCols = Math.min(items.length, Math.floor(masonryWidth / (minColWidth + gap)) || 1)
   $: itemsToCols = items.reduce(
@@ -45,7 +47,7 @@
   {#each itemsToCols as col}
     <div class="col {columnClass}" style="gap: {gap}px; max-width: {maxColWidth}px;">
       {#if animate}
-        {#each col as [item, idx] (getId(item))}
+        {#each col as [item, idx] (isIterator ? id(item) : item[id])}
           <div
             in:fade|local={{ delay: 100, duration }}
             out:fade|local={{ delay: 0, duration }}
@@ -55,7 +57,7 @@
           </div>
         {/each}
       {:else}
-        {#each col as [item, idx] (getId(item))}
+        {#each col as [item, idx] (isIterator ? id(item) : item[id])}
           <slot {idx} {item} />
         {/each}
       {/if}


### PR DESCRIPTION
This is more in-line with what I was thinking in regards to having one prop that could be passed as a function or string. In this instance the prop's type is checked using typeof, with that boolean value then used to either run the function on the item or use the string to get the key. It prevents redundancies like `<Masonry {items} idKey="hello" getId={(item) => item.world}>` where idKey isn't actually used. 

I'm not used to typescript so please excuse any errors. Also, ignore the previous PR, it had a copy/paste error from another repo I'm working in