### PR TITLE
Fix balanced-stable resize redistribution

### DIFF
--- a/src/lib/Masonry.svelte
+++ b/src/lib/Masonry.svelte
@@ -121,12 +121,7 @@
   // Reads from non-reactive cache, so won't trigger re-renders
   const get_height = (item: Item): number => {
     const id = getId(item)
-    return (
-      item_heights_cache.get(id) ??
-      getEstimatedHeight?.(item) ??
-      avg_measured_height ??
-      150
-    )
+    return item_heights_cache.get(id) || getEstimatedHeight?.(item) || avg_measured_height || 150
   }
 
   // Check if current order mode needs height measurements before distributing items

--- a/src/lib/Masonry.svelte
+++ b/src/lib/Masonry.svelte
@@ -82,8 +82,9 @@
     measured_count > 0 ? measured_sum / measured_count : null,
   )
 
-  // Tracks which column each item was assigned to (for balanced-stable mode)
+  // Tracks each item's assigned column (for balanced-stable mode)
   const stable_assignments = new Map<ItemId, number>()
+  let prev_stable_num_cols = 0
   const item_records = new Map<ItemId, ItemRecord>()
 
   // Clean up stale heights and stable assignments when items change (prevents memory leak)
@@ -100,11 +101,12 @@
       measured_sum -= removed_sum
       measured_count = item_heights_cache.size
     }
-    // Clean up stable_assignments and item_records for removed items
-    for (const map of [stable_assignments, item_records]) {
-      for (const id of map.keys()) {
-        if (!current_ids.has(id)) map.delete(id)
-      }
+    // Clean up removed items from stable assignments and item records
+    for (const id of stable_assignments.keys()) {
+      if (!current_ids.has(id)) stable_assignments.delete(id)
+    }
+    for (const id of item_records.keys()) {
+      if (!current_ids.has(id)) item_records.delete(id)
     }
   })
 
@@ -176,19 +178,22 @@
   }
 
   // Stable balancing: new items go to shortest column, existing items keep their column
-  // NOTE: This function intentionally mutates stable_assignments Map during $derived computation.
+  // NOTE: This function intentionally mutates stable_assignments during $derived computation.
   // This is safe because the Map is a non-reactive cache for persistence across renders,
   // not a reactive dependency. The derived recomputes based on items/nCols/order changes.
   function balanced_stable_to_cols(num_cols: number): ItemRecord[][] {
     const cols: ItemRecord[][] = Array.from({ length: num_cols }, () => [])
     const heights: number[] = Array.from({ length: num_cols }, () => 0)
 
+    if (num_cols > prev_stable_num_cols) stable_assignments.clear()
+    prev_stable_num_cols = num_cols
+
     for (const [idx, item] of items.entries()) {
       const id = getId(item)
       let col = stable_assignments.get(id)
 
       if (col === undefined || col >= num_cols) {
-        // New item or column count reduced - assign to shortest
+        // New or out-of-range item - assign to shortest
         col = heights.indexOf(Math.min(...heights))
         stable_assignments.set(id, col)
       }
@@ -411,7 +416,7 @@
   {...rest}
   class="masonry {rest.class ?? ``}"
 >
-  {#each itemsToCols as col, col_idx}
+  {#each itemsToCols as col, col_idx (col_idx)}
     {@const [start, end] = visible_ranges[col_idx]}
     {@const visible_items = col.slice(start, end)}
     <div

--- a/src/lib/Masonry.svelte
+++ b/src/lib/Masonry.svelte
@@ -101,12 +101,10 @@
       measured_sum -= removed_sum
       measured_count = item_heights_cache.size
     }
-    // Clean up removed items from stable assignments and item records
-    for (const id of stable_assignments.keys()) {
-      if (!current_ids.has(id)) stable_assignments.delete(id)
-    }
-    for (const id of item_records.keys()) {
-      if (!current_ids.has(id)) item_records.delete(id)
+    for (const stale_map of [stable_assignments, item_records]) {
+      for (const id of stale_map.keys()) {
+        if (!current_ids.has(id)) stale_map.delete(id)
+      }
     }
   })
 
@@ -120,19 +118,15 @@
     return record
   }
 
-  // Unified height getter with fallback chain
   // Reads from non-reactive cache, so won't trigger re-renders
   const get_height = (item: Item): number => {
     const id = getId(item)
-    // 1. Actual measured height (most accurate)
-    const measured = item_heights_cache.get(id)
-    if (measured !== undefined) return measured
-    // 2. User-provided estimate (if custom function provided)
-    if (getEstimatedHeight) return getEstimatedHeight(item)
-    // 3. Average of measured items
-    if (avg_measured_height) return avg_measured_height
-    // 4. Hard fallback
-    return 150
+    return (
+      item_heights_cache.get(id) ??
+      getEstimatedHeight?.(item) ??
+      avg_measured_height ??
+      150
+    )
   }
 
   // Check if current order mode needs height measurements before distributing items
@@ -331,7 +325,7 @@
 
   // Stable height for virtualization - ONLY estimates (no measured heights = no drift)
   const get_estimated_height = (item: Item): number =>
-    getEstimatedHeight ? getEstimatedHeight(item) : 150
+    getEstimatedHeight?.(item) ?? 150
 
   // Prefix height arrays per column: prefix_heights[col][i] = cumulative height of items 0..i
   // When virtualizing: use ONLY estimates (stable, no drift)
@@ -402,6 +396,12 @@
   <svelte:element this={`style`}>{container_query_css}</svelte:element>
 </svelte:head>
 
+{#snippet render_item(idx: number, item: Item)}
+  {#if children}{@render children({ idx, item })}{:else}
+    <span>{item}</span>
+  {/if}
+{/snippet}
+
 <div
   bind:clientWidth={masonryWidth}
   bind:clientHeight={masonryHeight}
@@ -431,24 +431,20 @@
       style={columnStyle || undefined}
     >
       {#if effective_animate}
-        {#each visible_items as record (record.id)}
+        {#each visible_items as { id, idx, item } (id)}
           <div
-            use:measure_height={record.id}
+            use:measure_height={id}
             in:fade={{ delay: 100, duration }}
             out:fade={{ delay: 0, duration }}
             animate:flip={{ duration }}
           >
-            {#if children}{@render children({ idx: record.idx, item: record.item })}{:else}
-              <span>{record.item}</span>
-            {/if}
+            {@render render_item(idx, item)}
           </div>
         {/each}
       {:else}
-        {#each visible_items as record (record.id)}
-          <div use:measure_height={record.id}>
-            {#if children}{@render children({ idx: record.idx, item: record.item })}{:else}
-              <span>{record.item}</span>
-            {/if}
+        {#each visible_items as { id, idx, item } (id)}
+          <div use:measure_height={id}>
+            {@render render_item(idx, item)}
           </div>
         {/each}
       {/if}

--- a/src/routes/edge-cases/+page.svelte
+++ b/src/routes/edge-cases/+page.svelte
@@ -66,27 +66,73 @@
   let next_id = $state(20)
   let items = $state(Array.from({ length: 20 }, (_, idx) => make_item(idx)))
 
+  function sync_item_count(): void {
+    n_items = items.length
+  }
+
+  function update_item_heights(): void {
+    items = items.map((item) => ({ ...item, height: rand_height() }))
+  }
+
+  function set_n_items(next_count: number): void {
+    n_items = next_count
+    if (next_count < items.length) {
+      items = items.slice(0, next_count)
+    } else {
+      add_items(next_count - items.length)
+    }
+  }
+
+  function set_min_height(next_height: number): void {
+    min_height = next_height
+    if (max_height < min_height) max_height = min_height
+    update_item_heights()
+  }
+
+  function set_max_height(next_height: number): void {
+    max_height = Math.max(next_height, min_height)
+    update_item_heights()
+  }
+
+  function set_fixed_height(next_fixed_height: boolean): void {
+    fixed_height = next_fixed_height
+    update_item_heights()
+  }
+
   function regenerate() {
     items = Array.from({ length: n_items }, (_, idx) => make_item(idx))
     next_id = n_items
   }
 
-  const add_item = () => {
-    items = [...items, make_item(next_id++)]
-  }
   const add_items = (count: number) => {
-    items = [...items, ...Array.from({ length: count }, () => make_item(next_id++))]
+    if (count <= 0) return
+    const start_id = next_id
+    next_id += count
+    items = [
+      ...items,
+      ...Array.from({ length: count }, (_, idx) => make_item(start_id + idx)),
+    ]
+    sync_item_count()
   }
-  const remove_last = () => (items = items.slice(0, -1))
+  const add_item = () => add_items(1)
+  const remove_last = () => {
+    items = items.slice(0, -1)
+    sync_item_count()
+  }
+  const randomize_items = () => {
+    items = items.map(({ id }) => make_item(id))
+  }
   const remove_random = () => {
     if (items.length > 0) {
       items = items.toSpliced(Math.floor(Math.random() * items.length), 1)
+      sync_item_count()
     }
   }
   const shuffle = () => (items = items.toSorted(() => Math.random() - 0.5))
   const clear_all = () => {
     items = []
     next_id = 0
+    sync_item_count()
   }
 
   // Stress test controls
@@ -181,6 +227,20 @@
       },
     },
     {
+      label: `Issue #60`,
+      action: () => {
+        order = `balanced-stable`
+        n_items = 12
+        min_col_width = 180
+        max_col_width = 260
+        gap = 20
+        container_width = 100
+        constrained_width = false
+        virtualize = false
+        regenerate()
+      },
+    },
+    {
       label: `No Gap`,
       action: () => {
         gap = 0
@@ -222,25 +282,43 @@
     <h2>Item Settings</h2>
     <label>
       <span>Number of items: <code>{n_items}</code></span>
-      <input type="range" bind:value={n_items} min={0} max={200} />
+      <input
+        type="range"
+        bind:value={() => n_items, set_n_items}
+        min={0}
+        max={200}
+      />
     </label>
     <label>
       <span>Min height: <code>{min_height}px</code></span>
-      <input type="range" bind:value={min_height} min={20} max={500} />
+      <input
+        type="range"
+        bind:value={() => min_height, set_min_height}
+        min={20}
+        max={500}
+      />
     </label>
     <label>
       <span>Max height: <code>{max_height}px</code></span>
-      <input type="range" bind:value={max_height} min={min_height} max={600} />
+      <input
+        type="range"
+        bind:value={() => max_height, set_max_height}
+        min={min_height}
+        max={600}
+      />
     </label>
     <label class="checkbox">
-      <input type="checkbox" bind:checked={fixed_height} />
+      <input
+        type="checkbox"
+        bind:checked={() => fixed_height, set_fixed_height}
+      />
       <span>Fixed height (use min only)</span>
     </label>
     <div class="button-row">
       <button onclick={regenerate}>Regenerate</button>
       <button onclick={add_item}>+ Add</button>
       <button onclick={remove_last}>- Remove</button>
-      <button onclick={remove_random}>🎲 Random</button>
+      <button onclick={randomize_items}>🎲 Random</button>
       <button onclick={shuffle}>🔀 Shuffle</button>
       <button onclick={clear_all}>🗑 Clear</button>
     </div>
@@ -267,7 +345,7 @@
     <label>
       <span>Order mode: <code>{order}</code></span>
       <select bind:value={order}>
-        {#each order_options as opt}
+        {#each order_options as opt (opt)}
           <option value={opt}>{opt}</option>
         {/each}
       </select>
@@ -315,7 +393,7 @@
       <input type="range" bind:value={overscan} min={1} max={20} disabled={!virtualize} />
     </label>
     <div class="button-row">
-      {#each [[`🚀`, 1000], [`🔥`, 5000]] as const as [icon, count]}
+      {#each [[`🚀`, 1000], [`🔥`, 5000]] as const as [icon, count] (count)}
         <button
           onclick={() => {
             virtualize = true
@@ -333,7 +411,7 @@
 <section class="presets">
   <h2>Quick Presets</h2>
   <div class="button-row">
-    {#each presets as { label, action }}
+    {#each presets as { label, action } (label)}
       <button onclick={action}>{label}</button>
     {/each}
   </div>
@@ -344,7 +422,7 @@
   <p>
     Test that Masonry resists CSS resets like
     <a href="https://tailwindcss.com/docs/preflight">Tailwind Preflight</a>. Toggle the
-    reset to inject <code>div {'{'} display: block {'}'}</code> into the page. Layout
+    reset to inject <code>div &#123; display: block &#125;</code> into the page. Layout
     should remain intact due to inline styles. (<a
       href="https://github.com/janosh/svelte-bricks/issues/48"
     >issue #48</a>)
@@ -446,7 +524,11 @@
     bind:masonryHeight={masonry_height}
   >
     {#snippet children({ item })}
-      <div class="item" style:height="{item.height}px" style:background={item.color}>
+      <div
+        class="item"
+        style:height="{item.height}px"
+        style:background={item.color}
+      >
         <span class="item-id">#{item.id}</span>
         <span class="item-height">{item.height}px</span>
       </div>

--- a/src/routes/edge-cases/+page.svelte
+++ b/src/routes/edge-cases/+page.svelte
@@ -30,7 +30,6 @@
   let max_col_width = $state(400)
   let gap = $state(15)
   let animate = $state(true)
-  let duration = $state(200)
   let order = $state<MasonryOrder>(`balanced`)
   let container_width = $state(100)
   let constrained_width = $state(false)
@@ -119,7 +118,7 @@
     items = items.slice(0, -1)
     sync_item_count()
   }
-  const randomize_items = () => {
+  const reroll_items = () => {
     items = items.map(({ id }) => make_item(id))
   }
   const remove_random = () => {
@@ -133,6 +132,17 @@
     items = []
     next_id = 0
     sync_item_count()
+  }
+
+  function apply_item_count_preset(count: number): void {
+    n_items = count
+    regenerate()
+  }
+
+  function apply_height_preset(min_height_px: number, max_height_px: number): void {
+    min_height = min_height_px
+    max_height = max_height_px
+    regenerate()
   }
 
   // Stress test controls
@@ -161,70 +171,19 @@
   const presets: { label: string; action: () => void }[] = [
     {
       label: `1 Item`,
-      action: () => {
-        n_items = 1
-        regenerate()
-      },
-    },
-    {
-      label: `3 Items`,
-      action: () => {
-        n_items = 3
-        regenerate()
-      },
+      action: () => apply_item_count_preset(1),
     },
     {
       label: `100 Items`,
-      action: () => {
-        n_items = 100
-        regenerate()
-      },
+      action: () => apply_item_count_preset(100),
     },
     {
       label: `Tall Items`,
-      action: () => {
-        min_height = 300
-        max_height = 500
-        regenerate()
-      },
+      action: () => apply_height_preset(300, 500),
     },
     {
       label: `Short Items`,
-      action: () => {
-        min_height = 30
-        max_height = 60
-        regenerate()
-      },
-    },
-    {
-      label: `Uniform Height`,
-      action: () => {
-        fixed_height = true
-        regenerate()
-      },
-    },
-    {
-      label: `Varied Height`,
-      action: () => {
-        fixed_height = false
-        min_height = 50
-        max_height = 400
-        regenerate()
-      },
-    },
-    {
-      label: `Narrow Cols`,
-      action: () => {
-        min_col_width = 100
-        max_col_width = 150
-      },
-    },
-    {
-      label: `Wide Cols`,
-      action: () => {
-        min_col_width = 400
-        max_col_width = 600
-      },
+      action: () => apply_height_preset(30, 60),
     },
     {
       label: `Issue #60`,
@@ -249,9 +208,8 @@
     {
       label: `200 Items`,
       action: () => {
-        n_items = 200
         min_col_width = 80
-        regenerate()
+        apply_item_count_preset(200)
       },
     },
   ]
@@ -270,11 +228,11 @@
   <title>Edge Cases | svelte-bricks</title>
 </svelte:head>
 
-<h1>Edge Cases & Stress Tests</h1>
+<h1>Edge Cases</h1>
 
 <p class="description">
-  Interactive demo to test the masonry layout with various edge cases and automated stress
-  tests. Use the controls to adjust parameters and observe layout behavior.
+  Interactive demo to test the masonry layout with unusual item, column, and container
+  settings.
 </p>
 
 <div class="controls-grid">
@@ -315,10 +273,9 @@
       <span>Fixed height (use min only)</span>
     </label>
     <div class="button-row">
-      <button onclick={regenerate}>Regenerate</button>
       <button onclick={add_item}>+ Add</button>
       <button onclick={remove_last}>- Remove</button>
-      <button onclick={randomize_items}>🎲 Random</button>
+      <button onclick={reroll_items}>🎲 Reroll</button>
       <button onclick={shuffle}>🔀 Shuffle</button>
       <button onclick={clear_all}>🗑 Clear</button>
     </div>
@@ -341,7 +298,7 @@
   </section>
 
   <section class="control-group">
-    <h2>Layout & Animation</h2>
+    <h2>Layout</h2>
     <label>
       <span>Order mode: <code>{order}</code></span>
       <select bind:value={order}>
@@ -353,10 +310,6 @@
     <label class="checkbox">
       <input type="checkbox" bind:checked={animate} />
       <span>Animate transitions</span>
-    </label>
-    <label>
-      <span>Duration: <code>{duration}ms</code></span>
-      <input type="range" bind:value={duration} min={0} max={1000} disabled={!animate} />
     </label>
   </section>
 
@@ -437,8 +390,54 @@
   </div>
 </section>
 
-<section class="stress-tests">
-  <h2>🔥 Automated Stress Tests</h2>
+<div class="stats">
+  <span>Width: <code>{masonry_width}px</code></span>
+  <span>Height: <code>{masonry_height}px</code></span>
+  <span>Columns: <code>{expected_cols}</code></span>
+  <span>Items: <code>{items.length}</code></span>
+  <span>Order: <code>{virtualize ? `row-first (forced)` : order}</code></span>
+</div>
+
+<div
+  class="masonry-container"
+  style:width="{container_width}%"
+  style:max-width={constrained_width ? `800px` : ``}
+>
+  <Masonry
+    {items}
+    minColWidth={min_col_width}
+    maxColWidth={max_col_width}
+    {gap}
+    {animate}
+    {order}
+    {virtualize}
+    {overscan}
+    height={virtualize ? virtual_height : undefined}
+    getEstimatedHeight={(item) => item.height}
+    bind:masonryWidth={masonry_width}
+    bind:masonryHeight={masonry_height}
+  >
+    {#snippet children({ item })}
+      <div
+        class="item"
+        style:height="{item.height}px"
+        style:background={item.color}
+      >
+        <span class="item-id">#{item.id}</span>
+        <span class="item-height">{item.height}px</span>
+      </div>
+    {/snippet}
+  </Masonry>
+</div>
+
+{#if items.length === 0}
+  <p class="empty-message">
+    No items to display. Add some items using the controls above.
+  </p>
+{/if}
+
+<details class="stress-tests">
+  <summary>🔥 Automated Stress Tests</summary>
   <div class="button-row">
     <button
       onclick={() => start_test(`rapid-add`, () => {}, () => add_items(1), 50)}
@@ -493,54 +492,7 @@
       Running: <strong>{test_mode}</strong> — Operations: <code>{operation_count}</code>
     </p>
   {/if}
-</section>
-
-<div class="stats">
-  <span>Width: <code>{masonry_width}px</code></span>
-  <span>Height: <code>{masonry_height}px</code></span>
-  <span>Columns: <code>{expected_cols}</code></span>
-  <span>Items: <code>{items.length}</code></span>
-  <span>Order: <code>{virtualize ? `row-first (forced)` : order}</code></span>
-</div>
-
-<div
-  class="masonry-container"
-  style:width="{container_width}%"
-  style:max-width={constrained_width ? `800px` : ``}
->
-  <Masonry
-    {items}
-    minColWidth={min_col_width}
-    maxColWidth={max_col_width}
-    {gap}
-    {animate}
-    {duration}
-    {order}
-    {virtualize}
-    {overscan}
-    height={virtualize ? virtual_height : undefined}
-    getEstimatedHeight={(item) => item.height}
-    bind:masonryWidth={masonry_width}
-    bind:masonryHeight={masonry_height}
-  >
-    {#snippet children({ item })}
-      <div
-        class="item"
-        style:height="{item.height}px"
-        style:background={item.color}
-      >
-        <span class="item-id">#{item.id}</span>
-        <span class="item-height">{item.height}px</span>
-      </div>
-    {/snippet}
-  </Masonry>
-</div>
-
-{#if items.length === 0}
-  <p class="empty-message">
-    No items to display. Add some items using the controls above.
-  </p>
-{/if}
+</details>
 
 <style>
   h1 {
@@ -659,10 +611,13 @@
   .css-reset-test a {
     color: cornflowerblue;
   }
-  .presets h2, .stress-tests h2, .css-reset-test h2 {
+  .presets h2, .stress-tests summary, .css-reset-test h2 {
     margin: 0 0 0.4em;
     font-size: 0.85rem;
     color: #aaa;
+  }
+  .stress-tests summary {
+    cursor: pointer;
   }
   .test-status {
     margin-top: 0.5em;

--- a/src/routes/virtual-scroll/+page.svelte
+++ b/src/routes/virtual-scroll/+page.svelte
@@ -7,14 +7,31 @@
 
   type Item = { id: number; height: number; hue: number }
 
+  const make_item = (id: number): Item => ({
+    id,
+    height: height.min + Math.floor(Math.random() * (height.max - height.min)),
+    hue: Math.floor(Math.random() * 360),
+  })
+
   const generate_items = (count: number): Item[] =>
-    Array.from({ length: count }, (_, idx) => ({
-      id: idx,
-      height: height.min + Math.floor(Math.random() * (height.max - height.min)),
-      hue: Math.floor(Math.random() * 360),
-    }))
+    Array.from({ length: count }, (_, idx) => make_item(idx))
 
   let items = $state(generate_items(2000))
+
+  function set_item_count(next_count: number): void {
+    item_count = next_count
+    if (next_count < items.length) {
+      items = items.slice(0, next_count)
+    } else {
+      const start_id = items.length
+      items = [
+        ...items,
+        ...Array.from({ length: next_count - items.length }, (_, idx) =>
+          make_item(start_id + idx)
+        ),
+      ]
+    }
+  }
 
   // Masonry settings
   let virtualize = $state(true)
@@ -58,7 +75,7 @@
   <section class="control-group">
     <h2>Items</h2>
     <div class="preset-row">
-      {#each presets as { label, count }}
+      {#each presets as { label, count } (count)}
         <button
           onclick={() => {
             item_count = count
@@ -72,9 +89,18 @@
     </div>
     <label>
       <span>Count: <code>{item_count.toLocaleString()}</code></span>
-      <input type="range" bind:value={item_count} min={100} max={20000} step={100} />
+      <input
+        type="range"
+        bind:value={() => item_count, set_item_count}
+        min={100}
+        max={20000}
+        step={100}
+      />
     </label>
-    <button class="regenerate" onclick={() => items = generate_items(item_count)}>
+    <button
+      class="regenerate"
+      onclick={() => items = generate_items(item_count)}
+    >
       🔄 Regenerate Items
     </button>
   </section>
@@ -108,7 +134,7 @@
     <label>
       <span>Order: <code>{virtualize ? `row-first (forced)` : order}</code></span>
       <select bind:value={order} disabled={virtualize}>
-        {#each order_options as opt}
+        {#each order_options as opt (opt)}
           <option value={opt}>{opt}</option>
         {/each}
       </select>

--- a/tests/fixtures/AppendRenderProbe.svelte
+++ b/tests/fixtures/AppendRenderProbe.svelte
@@ -5,3 +5,5 @@
     events.push(item.id)
   })
 </script>
+
+<span>{item.id}</span>

--- a/tests/fixtures/MasonryAppendHarness.svelte
+++ b/tests/fixtures/MasonryAppendHarness.svelte
@@ -5,16 +5,25 @@
   let { events }: { events: number[] } = $props()
 
   let items = $state([{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }])
+  let n_cols = $state(2)
 
   export const append = (...ids: number[]): void => {
     items = [...items, ...ids.map((id) => ({ id }))]
+  }
+
+  export const remove = (...ids: number[]): void => {
+    items = items.filter(({ id }) => !ids.includes(id))
+  }
+
+  export const set_cols = (next_cols: number): void => {
+    n_cols = next_cols
   }
 </script>
 
 <Masonry
   {items}
   animate={false}
-  calcCols={() => 2}
+  calcCols={() => n_cols}
   idKey="id"
   masonryWidth={500}
   order="balanced-stable"

--- a/tests/masonry.test.ts
+++ b/tests/masonry.test.ts
@@ -305,6 +305,34 @@ describe(`Masonry order modes`, () => {
     expect(columns[1].textContent).toMatch(/4.*5.*6/u)
   })
 
+  test(`order=balanced-stable repopulates columns after count increases`, async () => {
+    const harness = mount(MasonryAppendHarness, {
+      target: document.body,
+      props: { events: [] },
+    })
+    await tick()
+    const initial_cols = get_col_dist()
+    expect(initial_cols).toHaveLength(2)
+    expect(initial_cols[1].length).toBeGreaterThan(0)
+
+    harness.set_cols(1)
+    await tick()
+    const collapsed_cols = get_col_dist()
+    expect(collapsed_cols).toHaveLength(1)
+    expect(collapsed_cols[0].toSorted()).toEqual(initial_cols.flat().toSorted())
+
+    const removed_ids = initial_cols[1].map(Number)
+    harness.remove(...removed_ids)
+    await tick()
+
+    harness.set_cols(2)
+    await tick()
+    const expanded_cols = get_col_dist()
+    expect(expanded_cols).toHaveLength(2)
+    expect(expanded_cols.every((col) => col.length > 0)).toBe(true)
+    expect(expanded_cols.flat().toSorted()).toEqual(initial_cols[0].toSorted())
+  })
+
   test.each(ALL_ORDER_MODES)(
     `order=%s always attaches ResizeObservers for mode switching support`,
     async (order) => {

--- a/tests/masonry.test.ts
+++ b/tests/masonry.test.ts
@@ -333,6 +333,24 @@ describe(`Masonry order modes`, () => {
     expect(expanded_cols.flat().toSorted()).toEqual(initial_cols[0].toSorted())
   })
 
+  test(`order=balanced-stable ignores zero estimated heights`, async () => {
+    mock_height = 0
+    mount(Masonry, {
+      target: document.body,
+      props: {
+        items: make_items(3),
+        order: `balanced-stable`,
+        calcCols: () => 2,
+        gap: 0,
+        getEstimatedHeight: () => 0,
+        masonryWidth: 500,
+      },
+    })
+    await tick()
+
+    expect(get_col_dist()).toEqual([[`0`, `2`], [`1`]])
+  })
+
   test.each(ALL_ORDER_MODES)(
     `order=%s always attaches ResizeObservers for mode switching support`,
     async (order) => {

--- a/tests/playwright/demo-controls.test.ts
+++ b/tests/playwright/demo-controls.test.ts
@@ -1,0 +1,81 @@
+import { expect, test, type Page } from '@playwright/test'
+
+const edge_items = (page: Page) => page.locator(`.masonry-container .item`)
+
+function edge_item_heights(page: Page): Promise<number[]> {
+  return edge_items(page).evaluateAll((elements) =>
+    elements.map((element) => Number.parseFloat(getComputedStyle(element).height)),
+  )
+}
+
+const virtual_total_items = (page: Page) =>
+  page.locator(`.stat`).filter({ hasText: `Total Items` }).locator(`.stat-value`)
+
+test.describe(`Demo controls`, () => {
+  test(`edge cases item settings update rendered items immediately`, async ({ page }) => {
+    await page.goto(`/edge-cases`, { waitUntil: `networkidle` })
+    await expect(edge_items(page).first()).toBeVisible()
+    await expect(edge_items(page)).toHaveCount(20)
+
+    const item_settings = page
+      .locator(`.control-group`)
+      .filter({ hasText: `Item Settings` })
+    const count = page.getByLabel(/Number of items/)
+    await count.fill(`7`)
+    await expect(edge_items(page)).toHaveCount(7)
+
+    await item_settings.getByRole(`button`, { name: /Add/ }).click()
+    await expect(edge_items(page)).toHaveCount(8)
+    await expect(count).toHaveValue(`8`)
+
+    await item_settings.getByRole(`button`, { name: /Remove/ }).click()
+    await expect(edge_items(page)).toHaveCount(7)
+    await expect(count).toHaveValue(`7`)
+
+    await item_settings.getByRole(`button`, { name: /Random/ }).click()
+    await expect(edge_items(page)).toHaveCount(7)
+
+    await item_settings.getByRole(`button`, { name: /Shuffle/ }).click()
+    await expect(edge_items(page)).toHaveCount(7)
+
+    await page.getByLabel(/Min height/).fill(`250`)
+    await expect
+      .poll(async () => {
+        const heights = await edge_item_heights(page)
+        return heights.length === 7 && heights.every((height) => height >= 250)
+      })
+      .toBe(true)
+
+    await page.getByLabel(/Max height/).fill(`260`)
+    await expect
+      .poll(async () => {
+        const heights = await edge_item_heights(page)
+        return heights.every((height) => height >= 250 && height <= 260)
+      })
+      .toBe(true)
+
+    await page.getByLabel(/Fixed height/).check()
+    await expect.poll(() => edge_item_heights(page)).toEqual(Array(7).fill(250))
+
+    await item_settings.getByRole(`button`, { name: /Clear/ }).click()
+    await expect(edge_items(page)).toHaveCount(0)
+    await expect(count).toHaveValue(`0`)
+  })
+
+  test(`virtual scroll count slider updates rendered item state immediately`, async ({
+    page,
+  }) => {
+    await page.goto(`/virtual-scroll`, { waitUntil: `networkidle` })
+    await expect(virtual_total_items(page)).toHaveText(`2,000`)
+
+    const count = page.getByLabel(/Count/)
+    await count.fill(`500`)
+    await expect(virtual_total_items(page)).toHaveText(`500`)
+
+    await count.fill(`1000`)
+    await expect(virtual_total_items(page)).toHaveText(`1,000`)
+
+    await page.getByRole(`button`, { name: /Regenerate Items/ }).click()
+    await expect(virtual_total_items(page)).toHaveText(`1,000`)
+  })
+})

--- a/tests/playwright/demo-controls.test.ts
+++ b/tests/playwright/demo-controls.test.ts
@@ -32,7 +32,7 @@ test.describe(`Demo controls`, () => {
     await expect(edge_items(page)).toHaveCount(7)
     await expect(count).toHaveValue(`7`)
 
-    await item_settings.getByRole(`button`, { name: /Random/ }).click()
+    await item_settings.getByRole(`button`, { name: /Reroll/ }).click()
     await expect(edge_items(page)).toHaveCount(7)
 
     await item_settings.getByRole(`button`, { name: /Shuffle/ }).click()

--- a/tests/playwright/masonry-order-modes.test.ts
+++ b/tests/playwright/masonry-order-modes.test.ts
@@ -124,6 +124,21 @@ test.describe(`Masonry Order Modes`, () => {
       const items = get_items(page)
       await expect(items).toHaveCount(new_count)
     })
+
+    test(`repopulates columns after column count increases`, async ({ page }) => {
+      await set_order_mode(page, `balanced-stable`)
+      await wait_for_masonry_stable(page)
+
+      const filled_col_count = async (): Promise<number> =>
+        (await get_all_column_item_ids(page)).filter((ids) => ids.length > 0).length
+      const cols_input = page.locator(`[data-testid="cols-input"]`)
+
+      await cols_input.fill(`1`)
+      await expect.poll(filled_col_count).toBe(1)
+
+      await cols_input.fill(`3`)
+      await expect.poll(filled_col_count).toBe(3)
+    })
   })
 
   test.describe(`order=row-first`, () => {
@@ -375,9 +390,7 @@ test.describe(`Masonry Column Configuration`, () => {
     let columns = get_columns(page)
     await expect(columns).toHaveCount(3)
 
-    // Change to 4 columns
     await page.locator(`[data-testid="cols-input"]`).fill(`4`)
-    await page.locator(`[data-testid="cols-input"]`).blur()
     await wait_for_masonry_stable(page)
 
     columns = get_columns(page)


### PR DESCRIPTION
## Summary
- Rebuild `balanced-stable` assignments when column count grows so expanded layouts redistribute current items.
- Add unit and Playwright regressions for collapse/expand behavior, including removal while collapsed.

Closes #60

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Balanced-stable ordering now repopulates columns correctly when columns increase and avoids stale item records for more stable layouts

* **New Features**
  * Added an Issue `#60` preset and a visible stats bar; item-count and height controls now apply immediately

* **UI Improvements**
  * Demo controls updated: immediate apply for add/remove/reroll/shuffle/clear, more stable preset and option rendering

* **Tests**
  * New unit and E2E tests covering balanced-stable behavior, demo controls, and layout/virtualization stability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/janosh/svelte-bricks/pull/61?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->