### PR TITLE
Add initialCols SSR support

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -74,12 +74,12 @@ Additional optional props are:
    Whether to [FLIP-animate](https://svelte.dev/docs/svelte/svelte-animate) masonry items when viewport resizing or other events cause `items` to rearrange.
 
 1. ```ts
-   order: 'balanced' | 'balanced-stable' | 'row-first' | 'column-sequential' | 'column-balanced' = 'balanced'
+   order: 'balanced' | 'balanced-stable' | 'row-first' | 'column-sequential' | 'column-balanced' = 'balanced-stable'
    ```
 
    Controls how items are distributed across columns:
-   - `balanced` (default): Items are placed in the shortest column for optimal visual balance. Items may jump between columns when the list changes.
-   - `balanced-stable`: Like `balanced`, but existing items never move. New items go to the shortest column. Ideal for infinite scroll.
+   - `balanced`: Items are placed in the shortest column for optimal visual balance. Items may jump between columns when the list changes.
+   - `balanced-stable` (default): Like `balanced`, but existing items never move. New items go to the shortest column. Ideal for infinite scroll.
    - `row-first`: Round-robin distribution (1→2→3→1→2→3...). Predictable row-major order.
    - `column-sequential`: Fills columns sequentially (first N items in column 1, next N in column 2, etc.). Strict column-major order.
    - `column-balanced`: Height-aware column-first. Fills column 1 until it reaches target height, then column 2, etc. Maintains reading order while balancing heights.
@@ -99,7 +99,7 @@ Additional optional props are:
    initialCols?: number
    ```
 
-   Initial column count to use while `masonryWidth` is `0` during SSR. Pass it only when the server can infer the first client layout, for example from a known page/container width. If it matches the first measured client column count, SSR and hydration use the same column tree. Once `masonryWidth` is non-zero, `calcCols` takes over. If omitted, `Masonry` keeps the 1920px fallback and can still redistribute items during hydration.
+   Initial column count to use while `masonryWidth` is `0` during SSR. Pass it only when the server can infer the first client layout, for example from a known page/container width. If it matches the first measured client column count, stable or deterministic order modes can hydrate with the same column tree. Once `masonryWidth` is non-zero, `calcCols` takes over. If omitted, `Masonry` keeps the 1920px fallback, so smaller measured layouts may move items out of fallback-only columns during hydration, causing layout shift.
 
 1. ```ts
    class: string = ``

--- a/readme.md
+++ b/readme.md
@@ -36,6 +36,7 @@ The kitchen sink for this component looks something like this:
   let items = $derived([...Array(nItems).keys()])
 
   let [minColWidth, maxColWidth, gap] = [200, 800, 20]
+  let initialCols = 3 // optional SSR hint
   let width = $state(0), height = $state(0)
 </script>
 
@@ -46,6 +47,7 @@ Masonry size: <span>{width}px</span> &times; <span>{height}px</span> (w &times; 
   {minColWidth}
   {maxColWidth}
   {gap}
+  {initialCols}
   style="padding: 20px;"
   columnStyle="background-color: rgba(0, 0, 0, 0.1);"
   bind:masonryWidth={width}
@@ -92,6 +94,12 @@ Additional optional props are:
    ```
 
    Function used to compute the number of columns based on the masonry width, minimum column width and gap.
+
+1. ```ts
+   initialCols?: number
+   ```
+
+   Initial column count to use while `masonryWidth` is `0` during SSR. Pass it only when the server can infer the first client layout, for example from a known page/container width. If it matches the first measured client column count, SSR and hydration use the same column tree. Once `masonryWidth` is non-zero, `calcCols` takes over. If omitted, `Masonry` keeps the 1920px fallback and can still redistribute items during hydration.
 
 1. ```ts
    class: string = ``

--- a/src/lib/Masonry.svelte
+++ b/src/lib/Masonry.svelte
@@ -73,7 +73,6 @@
   } = $props()
 
   const masonry_id = ($props.id as () => string)()
-  const masonry_id_selector = `[data-masonry-id="${masonry_id}"]`
 
   // Height tracking for column balancing and virtualization
   // Use plain Map (not reactive) to avoid triggering re-renders on every measurement
@@ -247,7 +246,9 @@
     }
     return masonryWidth > 0
       ? calcCols(masonryWidth, minColWidth, gap)
-      : Math.min(items.length, initialCols ?? calcCols(1920, minColWidth, gap))
+      : initialCols === undefined
+        ? calcCols(1920, minColWidth, gap)
+        : Math.min(items.length, initialCols)
   })
 
   // Container query rules: breakpoint(n) = (minColWidth + gap) * n - gap
@@ -258,7 +259,7 @@
       const min_width = col === 1
         ? ``
         : `(min-width: ${(minColWidth + gap) * col - gap}px) and `
-      return `@container masonry ${min_width}(max-width: ${max_width}px) { ${masonry_id_selector} > .col:nth-child(n+${
+      return `@container masonry ${min_width}(max-width: ${max_width}px) { [data-masonry-id="${masonry_id}"] > .col:nth-child(n+${
         col + 1
       }) { display: none !important; } }`
     }).join(`\n`),

--- a/src/lib/Masonry.svelte
+++ b/src/lib/Masonry.svelte
@@ -29,6 +29,7 @@
       )
     },
     idKey = `id`,
+    initialCols,
     items,
     masonryHeight = $bindable(0),
     masonryWidth = $bindable(0),
@@ -52,6 +53,7 @@
     gap?: number
     getId?: (item: Item) => ItemId
     idKey?: string
+    initialCols?: number
     items: Item[]
     masonryHeight?: number
     masonryWidth?: number
@@ -69,6 +71,9 @@
     overscan?: number
     height?: number | string
   } = $props()
+
+  const masonry_id = ($props.id as () => string)()
+  const masonry_id_selector = `[data-masonry-id="${masonry_id}"]`
 
   // Height tracking for column balancing and virtualization
   // Use plain Map (not reactive) to avoid triggering re-renders on every measurement
@@ -231,21 +236,31 @@
       )
     }
   })
-  // CSS container queries hide excess columns for CLS-free SSR
-  // When masonryWidth is 0 (SSR), calculate max cols for 1920px viewport
-  let n_cols = $derived(calcCols(masonryWidth || 1920, minColWidth, gap))
+  // CSS container queries hide excess SSR columns before hydration
+  // When masonryWidth is 0 (SSR), prefer explicit initialCols before using the
+  // historical 1920px viewport fallback.
+  let n_cols = $derived.by(() => {
+    if (initialCols !== undefined && (!Number.isInteger(initialCols) || initialCols < 1)) {
+      throw new Error(
+        `svelte-bricks: initialCols must be a positive integer when provided, received ${initialCols}.`,
+      )
+    }
+    return masonryWidth > 0
+      ? calcCols(masonryWidth, minColWidth, gap)
+      : Math.min(items.length, initialCols ?? calcCols(1920, minColWidth, gap))
+  })
 
   // Container query rules: breakpoint(n) = (minColWidth + gap) * n - gap
   let container_query_css = $derived(
     Array.from({ length: n_cols - 1 }, (_, idx) => {
       const col = idx + 1
-      const max_w = (minColWidth + gap) * (col + 1) - gap - 1
-      const min_w = col === 1
+      const max_width = (minColWidth + gap) * (col + 1) - gap - 1
+      const min_width = col === 1
         ? ``
         : `(min-width: ${(minColWidth + gap) * col - gap}px) and `
-      return `@container masonry ${min_w}(max-width: ${max_w}px) { .masonry > .col:nth-child(n+${
+      return `@container masonry ${min_width}(max-width: ${max_width}px) { ${masonry_id_selector} > .col:nth-child(n+${
         col + 1
-      }) { display: none; } }`
+      }) { display: none !important; } }`
     }).join(`\n`),
   )
 
@@ -382,7 +397,7 @@
   let effective_animate = $derived(animate && !can_virtualize)
 </script>
 
-<!-- Dynamic container query styles in <head> for CLS-free SSR -->
+<!-- Dynamic container query styles in <head> hide excess SSR columns -->
 <svelte:head>
   <svelte:element this={`style`}>{container_query_css}</svelte:element>
 </svelte:head>
@@ -406,6 +421,7 @@
   : undefined}
   {...rest}
   class="masonry {rest.class ?? ``}"
+  data-masonry-id={masonry_id}
 >
   {#each itemsToCols as col, col_idx (col_idx)}
     {@const [start, end] = visible_ranges[col_idx]}

--- a/src/routes/cls-demo/+page.svelte
+++ b/src/routes/cls-demo/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { onMount } from 'svelte'
   import Masonry from '$lib'
 
   // Track hydration
@@ -18,6 +19,7 @@
   let simulate_slow_load = $state(true)
   let masonry_width = $state(0)
   let cls_events = $state<string[]>([])
+  const image_count = 15
 
   type Image = {
     id: number
@@ -30,9 +32,9 @@
   const get_load_delay = (idx: number, batch: number): number =>
     500 + ((idx * 397 + batch * 211) % 2000)
 
-  const generate_images = (count: number, batch = 0): Image[] =>
-    Array.from({ length: count }, (_, idx) => ({
-      id: batch * count + idx,
+  const generate_images = (batch = 0): Image[] =>
+    Array.from({ length: image_count }, (_, idx) => ({
+      id: batch * image_count + idx,
       width: 300,
       height: 150 + ((idx * 73 + batch * 41) % 250),
       loaded: !simulate_slow_load,
@@ -40,21 +42,39 @@
     }))
 
   function simulate_loading(): void {
-    images.forEach((img, idx) => {
-      if (!img.loaded) {
-        setTimeout(
-          () => (images[idx] = { ...images[idx], loaded: true }),
-          img.load_delay,
-        )
-      }
+    const batch = ++loading_batch
+    images.forEach(({ id, loaded, load_delay }, idx) => {
+      if (loaded) return
+      setTimeout(() => {
+        const current_image = images[idx]
+        if (batch === loading_batch && current_image?.id === id) {
+          images[idx] = { ...current_image, loaded: true }
+        }
+      }, load_delay)
     })
   }
 
   let image_batch = 0
-  let images = $state(generate_images(15))
+  let loading_batch = 0
+  let images = $state(generate_images())
+
+  function regenerate_images(): void {
+    image_batch += 1
+    images = generate_images(image_batch)
+    if (simulate_slow_load) simulate_loading()
+  }
+
+  function reset_loading_state(): void {
+    images = images.map((image, idx) => ({
+      ...image,
+      loaded: false,
+      load_delay: get_load_delay(idx, image_batch),
+    }))
+    simulate_loading()
+  }
 
   // Simulate image loading on mount if slow load is enabled
-  $effect(() => {
+  onMount(() => {
     if (simulate_slow_load) simulate_loading()
   })
 
@@ -91,9 +111,9 @@
 <p class="description">
   This page demonstrates how the masonry layout reduces Cumulative Layout Shift (CLS).
   It passes a deterministic <code>initialCols</code> value for SSR. When that value
-  matches the first measured client column count, SSR and hydration use the same
-  masonry column tree; otherwise CSS container queries still hide excess columns before
-  JavaScript runs.
+  matches the first measured client column count, stable order modes can hydrate with
+  the same masonry column tree; otherwise CSS container queries still hide excess
+  columns before JavaScript runs.
 </p>
 
 <section class="info-panel">
@@ -153,25 +173,8 @@
       <input type="checkbox" bind:checked={simulate_slow_load} />
       <span>Simulate slow image loading</span>
     </label>
-    <button
-      onclick={() => {
-        image_batch += 1
-        images = generate_images(15, image_batch)
-      }}
-    >
-      🔄 Regenerate Images
-    </button>
-    <button
-      onclick={() => {
-        images = images.map((img, idx) => ({
-          ...img,
-          loaded: false,
-          load_delay: get_load_delay(idx, image_batch),
-        }))
-        simulate_loading()
-      }}
-      disabled={!simulate_slow_load}
-    >
+    <button onclick={regenerate_images}>🔄 Regenerate Images</button>
+    <button onclick={reset_loading_state} disabled={!simulate_slow_load}>
       ⏳ Reset Loading State
     </button>
   </div>
@@ -180,6 +183,7 @@
 <div class="masonry-container">
   <Masonry
     items={images}
+    order="balanced-stable"
     minColWidth={min_col_width}
     initialCols={initial_cols}
     {gap}
@@ -246,8 +250,8 @@
         <p>
           After hydration, JavaScript measures the actual width and calculates the client
           column count. Once <code>masonryWidth</code> is greater than 0, the measured
-          <code>calcCols</code> result wins over <code>initialCols</code>; no item
-          redistribution occurs when both counts match.
+          <code>calcCols</code> result wins over <code>initialCols</code>; stable order
+          modes avoid item redistribution when both counts match.
         </p>
       </div>
     </div>

--- a/src/routes/cls-demo/+page.svelte
+++ b/src/routes/cls-demo/+page.svelte
@@ -41,30 +41,39 @@
       load_delay: simulate_slow_load ? get_load_delay(idx, batch) : 0,
     }))
 
+  let loading_timeouts: ReturnType<typeof setTimeout>[] = []
+
+  function clear_loading_timeouts(): void {
+    loading_timeouts.forEach(clearTimeout)
+    loading_timeouts = []
+  }
+
   function simulate_loading(): void {
-    const batch = ++loading_batch
+    clear_loading_timeouts()
     images.forEach(({ id, loaded, load_delay }, idx) => {
       if (loaded) return
-      setTimeout(() => {
+      const timeout = setTimeout(() => {
         const current_image = images[idx]
-        if (batch === loading_batch && current_image?.id === id) {
+        if (current_image?.id === id) {
           images[idx] = { ...current_image, loaded: true }
         }
       }, load_delay)
+      loading_timeouts.push(timeout)
     })
   }
 
   let image_batch = 0
-  let loading_batch = 0
   let images = $state(generate_images())
 
   function regenerate_images(): void {
+    clear_loading_timeouts()
     image_batch += 1
     images = generate_images(image_batch)
     if (simulate_slow_load) simulate_loading()
   }
 
   function reset_loading_state(): void {
+    clear_loading_timeouts()
     images = images.map((image, idx) => ({
       ...image,
       loaded: false,
@@ -76,6 +85,7 @@
   // Simulate image loading on mount if slow load is enabled
   onMount(() => {
     if (simulate_slow_load) simulate_loading()
+    return clear_loading_timeouts
   })
 
   // Observe CLS

--- a/src/routes/cls-demo/+page.svelte
+++ b/src/routes/cls-demo/+page.svelte
@@ -14,6 +14,7 @@
   // State
   let min_col_width = $state(200)
   let gap = $state(15)
+  let initial_cols = $state(4)
   let simulate_slow_load = $state(true)
   let masonry_width = $state(0)
   let cls_events = $state<string[]>([])
@@ -26,18 +27,19 @@
     load_delay: number
   }
 
-  const rand_delay = () => 500 + Math.floor(Math.random() * 2000)
+  const get_load_delay = (idx: number, batch: number): number =>
+    500 + ((idx * 397 + batch * 211) % 2000)
 
-  const generate_images = (count: number): Image[] =>
+  const generate_images = (count: number, batch = 0): Image[] =>
     Array.from({ length: count }, (_, idx) => ({
-      id: idx,
+      id: batch * count + idx,
       width: 300,
-      height: 150 + Math.floor(Math.random() * 250),
+      height: 150 + ((idx * 73 + batch * 41) % 250),
       loaded: !simulate_slow_load,
-      load_delay: simulate_slow_load ? rand_delay() : 0,
+      load_delay: simulate_slow_load ? get_load_delay(idx, batch) : 0,
     }))
 
-  function simulate_loading() {
+  function simulate_loading(): void {
     images.forEach((img, idx) => {
       if (!img.loaded) {
         setTimeout(
@@ -48,6 +50,7 @@
     })
   }
 
+  let image_batch = 0
   let images = $state(generate_images(15))
 
   // Simulate image loading on mount if slow load is enabled
@@ -73,11 +76,10 @@
     return () => observer?.disconnect()
   })
 
-  const calc_cols = (width: number) =>
+  const calc_cols = (width: number): number =>
     Math.min(images.length, Math.floor((width + gap) / (min_col_width + gap)) || 1)
 
-  let ssr_cols = $derived(calc_cols(1920))
-  let actual_cols = $derived(masonry_width > 0 ? calc_cols(masonry_width) : ssr_cols)
+  let actual_cols = $derived(masonry_width > 0 ? calc_cols(masonry_width) : initial_cols)
 </script>
 
 <svelte:head>
@@ -87,9 +89,11 @@
 <h1>📊 CLS Visualization</h1>
 
 <p class="description">
-  This page demonstrates how the masonry layout handles Cumulative Layout Shift (CLS). The
-  CSS container queries ensure the correct number of columns render immediately, even
-  before JavaScript measures the container width.
+  This page demonstrates how the masonry layout reduces Cumulative Layout Shift (CLS).
+  It passes a deterministic <code>initialCols</code> value for SSR. When that value
+  matches the first measured client column count, SSR and hydration use the same
+  masonry column tree; otherwise CSS container queries still hide excess columns before
+  JavaScript runs.
 </p>
 
 <section class="info-panel">
@@ -112,8 +116,8 @@
       }</span>
     </div>
     <div class="status-item">
-      <span class="label">SSR columns (max):</span>
-      <span class="value">{ssr_cols}</span>
+      <span class="label">SSR columns:</span>
+      <span class="value">{initial_cols}</span>
     </div>
     <div class="status-item">
       <span class="label">Actual columns:</span>
@@ -121,8 +125,8 @@
     </div>
     <div class="status-item">
       <span class="label">Column match:</span>
-      <span class="value" class:success={ssr_cols >= actual_cols}>{
-        ssr_cols >= actual_cols ? `✓ CSS covers` : `⚠ May shift`
+      <span class="value" class:success={initial_cols === actual_cols}>{
+        initial_cols === actual_cols ? `✓ Exact SSR` : `⚠ Hint mismatch`
       }</span>
     </div>
   </div>
@@ -139,19 +143,30 @@
       <span>gap: <code>{gap}px</code></span>
       <input type="range" bind:value={gap} min={0} max={40} />
     </label>
+    <label>
+      <span>initialCols: <code>{initial_cols}</code></span>
+      <input type="range" bind:value={initial_cols} min={1} max={8} />
+    </label>
   </div>
   <div class="button-row">
     <label class="checkbox">
       <input type="checkbox" bind:checked={simulate_slow_load} />
       <span>Simulate slow image loading</span>
     </label>
-    <button onclick={() => images = generate_images(15)}>🔄 Regenerate Images</button>
     <button
       onclick={() => {
-        images = images.map((img) => ({
+        image_batch += 1
+        images = generate_images(15, image_batch)
+      }}
+    >
+      🔄 Regenerate Images
+    </button>
+    <button
+      onclick={() => {
+        images = images.map((img, idx) => ({
           ...img,
           loaded: false,
-          load_delay: rand_delay(),
+          load_delay: get_load_delay(idx, image_batch),
         }))
         simulate_loading()
       }}
@@ -166,6 +181,7 @@
   <Masonry
     items={images}
     minColWidth={min_col_width}
+    initialCols={initial_cols}
     {gap}
     bind:masonryWidth={masonry_width}
   >
@@ -200,15 +216,16 @@
 {/if}
 
 <section class="explanation">
-  <h2>How CLS Prevention Works</h2>
+  <h2>How CLS Mitigation Works</h2>
   <div class="explanation-content">
     <div class="step">
       <span class="step-num">1</span>
       <div>
-        <strong>SSR renders maximum columns</strong>
+        <strong>SSR renders initial columns</strong>
         <p>
-          On the server, <code>masonryWidth</code> is 0. Instead of defaulting to 1
-          column, we calculate the maximum columns that could fit a 1920px viewport.
+          On the server, <code>masonryWidth</code> is 0. This demo passes
+          <code>initialCols</code> so SSR can render the same number of columns the
+          client will use after its first width measurement.
         </p>
       </div>
     </div>
@@ -217,18 +234,20 @@
       <div>
         <strong>CSS container queries hide excess</strong>
         <p>
-          Dynamic <code>@container</code> rules immediately hide columns that don't fit
-          the actual container width. This happens purely in CSS, before any JS runs.
+          Dynamic <code>@container</code> rules immediately hide SSR columns that don't
+          fit the actual container width. This happens purely in CSS, before any JS runs.
         </p>
       </div>
     </div>
     <div class="step">
       <span class="step-num">3</span>
       <div>
-        <strong>JS hydrates and confirms</strong>
+        <strong>JS hydrates and measures</strong>
         <p>
-          After hydration, JavaScript measures the actual width and calculates the correct
-          column count. Since CSS was already showing the right number, there's no shift.
+          After hydration, JavaScript measures the actual width and calculates the client
+          column count. Once <code>masonryWidth</code> is greater than 0, the measured
+          <code>calcCols</code> result wins over <code>initialCols</code>; no item
+          redistribution occurs when both counts match.
         </p>
       </div>
     </div>

--- a/src/routes/test/initial-cols/+page.svelte
+++ b/src/routes/test/initial-cols/+page.svelte
@@ -1,0 +1,54 @@
+<script lang="ts">
+  import Masonry from '$lib'
+
+  const items = [0, 1, 2, 3, 4, 5, 6, 7, 8]
+
+  let exact_masonry_width = $state(0)
+</script>
+
+<section data-testid="exact-masonry" style="width: 400px">
+  <p data-testid="exact-masonry-width">Measured width: {exact_masonry_width}px</p>
+
+  <Masonry
+    items={items.slice(0, 6)}
+    order="row-first"
+    initialCols={2}
+    minColWidth={200}
+    gap={0}
+    animate={false}
+    bind:masonryWidth={exact_masonry_width}
+  >
+    {#snippet children({ item })}
+      <div data-item-id={`A${item}`}>A{item}</div>
+    {/snippet}
+  </Masonry>
+</section>
+
+<section data-testid="wide-masonry" style="width: 360px">
+  <Masonry
+    {items}
+    order="row-first"
+    initialCols={3}
+    minColWidth={120}
+    gap={0}
+    animate={false}
+  >
+    {#snippet children({ item })}
+      <div data-item-id={`B${item}`}>B{item}</div>
+    {/snippet}
+  </Masonry>
+</section>
+
+<section data-testid="fallback-masonry" style="width: 360px">
+  <Masonry
+    items={items.slice(0, 8)}
+    order="row-first"
+    minColWidth={100}
+    gap={0}
+    animate={false}
+  >
+    {#snippet children({ item })}
+      <div data-item-id={`F${item}`}>F{item}</div>
+    {/snippet}
+  </Masonry>
+</section>

--- a/tests/masonry.test.ts
+++ b/tests/masonry.test.ts
@@ -200,17 +200,47 @@ describe(`Masonry`, () => {
     )
   })
 
+  test.each([
+    [{ initialCols: 4, masonryWidth: 0 }, 4],
+    [{ initialCols: 99, masonryWidth: 0 }, n_items],
+    [{ initialCols: 4, masonryWidth: 500, calcCols: () => 2 }, 2],
+  ])(`resolves column count from %o`, (props, expected) => {
+    mount(Masonry, {
+      target: document.body,
+      props: { items: indices, ...props },
+    })
+    expect(document.querySelectorAll(`div.masonry > div.col`).length).toBe(expected)
+  })
+
+  test.each([0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY])(
+    `throws for invalid initialCols=%s even after width is measured`,
+    (initialCols) => {
+      expect(() =>
+        mount(Masonry, {
+          target: document.body,
+          props: { items: indices, initialCols, masonryWidth: 500 },
+        }),
+      ).toThrow(`svelte-bricks: initialCols must be a positive integer when provided`)
+    },
+  )
+
   test(`injects named container query CSS into <head>`, () => {
     mount(Masonry, {
       target: document.body,
       props: { items: indices, minColWidth: 200, gap: 10 },
     })
+    const masonry_id = document
+      .querySelector(`div.masonry`)
+      ?.getAttribute(`data-masonry-id`)
+    if (!masonry_id) throw new Error(`data-masonry-id not found`)
     const head_styles = Array.from(document.head.querySelectorAll(`style`))
     const container_css = head_styles.find((style_el) =>
-      style_el.textContent.includes(`@container masonry`),
+      style_el.textContent.includes(`[data-masonry-id="${masonry_id}"]`),
     )?.textContent
     expect(container_css).toContain(`@container masonry`)
-    expect(container_css).toContain(`.masonry > .col:nth-child`)
+    expect(container_css).toContain(`[data-masonry-id="${masonry_id}"] > .col:nth-child`)
+    expect(container_css).not.toContain(`.masonry > .col:nth-child`)
+    expect(container_css).toContain(`display: none !important`)
     // no unnamed @container queries should remain (regression guard for #56)
     expect(container_css).not.toMatch(/@container\s*\(/u)
     // styles must be in <head> not <body> to avoid flash on SSR first paint

--- a/tests/masonry.test.ts
+++ b/tests/masonry.test.ts
@@ -203,7 +203,8 @@ describe(`Masonry`, () => {
   test.each([
     [{ initialCols: 4, masonryWidth: 0 }, 4],
     [{ initialCols: 99, masonryWidth: 0 }, n_items],
-    [{ initialCols: 4, masonryWidth: 500, calcCols: () => 2 }, 2],
+    [{ masonryWidth: 0, calcCols: (): number => 40 }, 40],
+    [{ initialCols: 4, masonryWidth: 500, calcCols: (): number => 2 }, 2],
   ])(`resolves column count from %o`, (props, expected) => {
     mount(Masonry, {
       target: document.body,
@@ -214,11 +215,11 @@ describe(`Masonry`, () => {
 
   test.each([0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY])(
     `throws for invalid initialCols=%s even after width is measured`,
-    (initialCols) => {
+    (initial_cols) => {
       expect(() =>
         mount(Masonry, {
           target: document.body,
-          props: { items: indices, initialCols, masonryWidth: 500 },
+          props: { items: indices, initialCols: initial_cols, masonryWidth: 500 },
         }),
       ).toThrow(`svelte-bricks: initialCols must be a positive integer when provided`)
     },

--- a/tests/playwright/cls-ssr.test.ts
+++ b/tests/playwright/cls-ssr.test.ts
@@ -1,0 +1,68 @@
+import { expect, test, type Browser, type Page } from '@playwright/test'
+
+const viewport = { width: 500, height: 800 }
+const route = `/test/initial-cols`
+
+async function open_page(browser: Browser, java_script_enabled: boolean): Promise<Page> {
+  const page = await browser.newPage({ javaScriptEnabled: java_script_enabled, viewport })
+  await page.goto(route, {
+    waitUntil: java_script_enabled ? `networkidle` : `domcontentloaded`,
+  })
+  return page
+}
+
+const masonry_columns = (page: Page, test_id: string) =>
+  page.locator(`[data-testid="${test_id}"] div.masonry > div.col`)
+
+const column_displays = (page: Page, test_id: string): Promise<string[]> =>
+  masonry_columns(page, test_id).evaluateAll((elements) =>
+    elements.map((element) => getComputedStyle(element).display),
+  )
+
+const visible_item_ids = (page: Page, test_id: string): Promise<string[][]> =>
+  masonry_columns(page, test_id).evaluateAll((elements) =>
+    elements
+      .filter((element) => getComputedStyle(element).display !== `none`)
+      .map((element) =>
+        Array.from(element.querySelectorAll(`[data-item-id]`)).map(
+          (item) => item.getAttribute(`data-item-id`) ?? ``,
+        ),
+      ),
+  )
+
+const expected_displays = (visible_count: number, total_count: number): string[] => [
+  ...Array(visible_count).fill(`grid`),
+  ...Array(total_count - visible_count).fill(`none`),
+]
+
+const ssr_cases = [
+  [`exact-masonry`, 2, 2],
+  [`wide-masonry`, 3, 3],
+  [`fallback-masonry`, 3, 8],
+] as const
+
+test(`SSR CSS is scoped and initialCols prevents hydration redistribution`, async ({
+  browser,
+}) => {
+  const ssr_page = await open_page(browser, false)
+  await Promise.all(
+    ssr_cases.map(async ([test_id, visible_count, total_count]) => {
+      await expect(masonry_columns(ssr_page, test_id)).toHaveCount(total_count)
+      expect(await column_displays(ssr_page, test_id)).toEqual(
+        expected_displays(visible_count, total_count),
+      )
+    }),
+  )
+  const ssr_exact_items = await visible_item_ids(ssr_page, `exact-masonry`)
+  const ssr_wide_items = await visible_item_ids(ssr_page, `wide-masonry`)
+  await ssr_page.close()
+
+  const hydrated_page = await open_page(browser, true)
+  await expect(hydrated_page.getByTestId(`exact-masonry-width`)).toHaveText(
+    `Measured width: 400px`,
+  )
+
+  expect(await visible_item_ids(hydrated_page, `exact-masonry`)).toEqual(ssr_exact_items)
+  expect(await visible_item_ids(hydrated_page, `wide-masonry`)).toEqual(ssr_wide_items)
+  await hydrated_page.close()
+})

--- a/tests/playwright/demo-controls.test.ts
+++ b/tests/playwright/demo-controls.test.ts
@@ -12,6 +12,26 @@ const virtual_total_items = (page: Page) =>
   page.locator(`.stat`).filter({ hasText: `Total Items` }).locator(`.stat-value`)
 
 test.describe(`Demo controls`, () => {
+  test(`CLS demo reset ignores stale image loading timers`, async ({ page }) => {
+    await page.clock.install()
+    await page.goto(`/cls-demo`, { waitUntil: `domcontentloaded` })
+
+    const first_loading = page.getByText(`Loading #0...`)
+    await expect(first_loading).toBeVisible()
+
+    await page.clock.fastForward(499)
+    await page.getByRole(`button`, { name: /Reset Loading State/ }).click()
+
+    await page.clock.fastForward(1)
+    await expect(first_loading).toBeVisible()
+
+    await page.clock.fastForward(498)
+    await expect(first_loading).toBeVisible()
+
+    await page.clock.fastForward(1)
+    await expect(first_loading).toBeHidden()
+  })
+
   test(`edge cases item settings update rendered items immediately`, async ({ page }) => {
     await page.goto(`/edge-cases`, { waitUntil: `networkidle` })
     await expect(edge_items(page).first()).toBeVisible()


### PR DESCRIPTION
## Summary
- Add an `initialCols` SSR hint so server-rendered and hydrated Masonry layouts can use the same column tree when the first client column count is known.
- Scope generated SSR container-query CSS per Masonry instance and keep the `display: none !important` fallback for omitted hints.
- Add deterministic browser coverage for fallback hiding, scoped CSS, and no-redistribution hydration, plus README/demo docs for the SSR contract.

## Verification
- `vp test --run tests/masonry.test.ts`
- `npx playwright test tests/playwright/cls-ssr.test.ts`
- `npm test`

Fixes #62

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional initialCols prop to control initial column count during SSR.

* **Documentation**
  * README updated with usage example, SSR/hydration guidance, initialCols API, and expanded distribution mode docs.

* **Improvements**
  * Demo UI updated to surface SSR columns and renamed guidance to "CLS Mitigation"; deterministic image loading and reset behavior for reliable demos.

* **Bug Fixes**
  * Scoped injected CSS to prevent cross-instance style clashes before hydration.

* **Tests**
  * Unit and end-to-end tests added/expanded for initialCols, SSR/hydration scenarios, CSS scoping, and demo timing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/janosh/svelte-bricks/pull/63?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->